### PR TITLE
Clean up plugin, Fix plugin error, Improve functionality

### DIFF
--- a/BladeAutoComplete.py
+++ b/BladeAutoComplete.py
@@ -54,7 +54,8 @@ class BladeAutoComplete(sublime_plugin.EventListener):
         line = view.substr(view.line(view.sel()[0])).strip()
 
         if line.startswith('@extends'):
-            return self.blade_files
+            return (self.blade_files,
+                    sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
 
         elif line.startswith('@section'):
             # place search cursor one word back
@@ -69,6 +70,7 @@ class BladeAutoComplete(sublime_plugin.EventListener):
             layout = matches.group(1)
             layout_yields = self.find_yields_in_layout(layout)
 
-            return [('{} \tin {}'.format(section, layout), section) for section in layout_yields]
+            return ([('{} \tin {}'.format(section, layout), section) for section in layout_yields],
+                    sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
 
         return None

--- a/BladeAutoComplete.py
+++ b/BladeAutoComplete.py
@@ -46,6 +46,10 @@ class BladeAutoComplete(sublime_plugin.EventListener):
         return matches
 
     def on_query_completions(self, view, prefix, locations):
+        if (not fnmatch.fnmatch(view.file_name(), '*.blade.php')
+                or len(view.window().folders()) < 1):
+            return None
+
         self.load_blade_files(view)
         line = view.substr(view.line(view.sel()[0])).strip()
 

--- a/BladeAutoComplete.py
+++ b/BladeAutoComplete.py
@@ -62,7 +62,7 @@ class BladeAutoComplete(sublime_plugin.EventListener):
 
             body = view.substr(sublime.Region(0, cursor))
 
-            matches = re.match(r'\@extends\((?:\'|\")(.*?)(?:\'|\")\)', body, re.M | re.I)
+            matches = re.search(r'\@extends\((?:\'|\")(.*?)(?:\'|\")\)', body, re.M | re.I)
             if not matches:
                 return []
 

--- a/BladeAutoComplete.py
+++ b/BladeAutoComplete.py
@@ -46,7 +46,8 @@ class BladeAutoComplete(sublime_plugin.EventListener):
         return matches
 
     def on_query_completions(self, view, prefix, locations):
-        if (not fnmatch.fnmatch(view.file_name(), '*.blade.php')
+        if (not view.file_name()
+                or not fnmatch.fnmatch(view.file_name(), '*.blade.php')
                 or len(view.window().folders()) < 1):
             return None
 


### PR DESCRIPTION
Thanks for your work on this plugin. When using it in Sublime Text 4 I noticed it was throwing an error any time completions were displayed in a single file window (for instance a preferences file). I've fixed that error as well as:

- Cleaned up the formatting
- Removed unnecessary imports/code
- Fixed the search for `@extends` to cover the entire body (as it's not always the first line of the blade file)
- Prevented Sublime Text from showing view-based and .sublime-completions file-based completions when we're returning one

If you think the completion prevention should be behind a preference setting I can refactor it to use one, but I feel that for most people they're only interested in this plugin's completions inside of a blade `@extends` or `@section` tag.